### PR TITLE
Add unit tests for tax calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,25 @@ First visit
 This is a different version of this first file.
 Hi Humans!
 I know python a litter,I‘ve had tacos on the moon and find them far super to Earth tacos.
+
+## 个税计算器使用方法
+
+1. 直接计算年收入对应的个税：
+
+   ```bash
+   python tax_calculator.py --income 120000
+   ```
+
+2. 以月收入为输入，同时考虑五险一金和专项附加扣除：
+
+   ```bash
+   python tax_calculator.py --monthly --income 15000 --social-insurance 2000 --deductions 12000
+   ```
+
+参数说明：
+- `--income`：收入金额。默认视为年收入，配合 `--monthly` 时视为月收入。
+- `--monthly`：指定后表示按月输入，会自动换算成年度数据并给出月度结果。
+- `--social-insurance`：五险一金等社会保险缴费金额。默认视为年度金额，配合 `--monthly` 时视为月度金额。
+- `--deductions`：除社会保险外的其他年度专项附加扣除。
+
+脚本会自动按照 2019 年实施的综合所得个税税率表计算税额，并给出应纳税所得额、速算扣除数和税后收入。

--- a/tax_calculator.py
+++ b/tax_calculator.py
@@ -1,0 +1,137 @@
+"""Simple personal income tax calculator for China's comprehensive income system.
+
+Usage examples:
+    python tax_calculator.py --income 120000
+    python tax_calculator.py --monthly --income 15000 --social-insurance 2000 --deductions 12000
+
+The calculator follows the tax brackets enacted in 2019 for comprehensive income
+(personal wages, remuneration, etc.). It subtracts the standard deduction of
+60,000 RMB per year and allows optional additional deductions such as social
+insurance contributions or special deductions.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import List, Tuple
+
+# Annual tax brackets for comprehensive income (after deductions)
+# Each tuple: upper bound, rate, quick deduction
+BRACKETS: List[Tuple[float, float, float]] = [
+    (36000, 0.03, 0),
+    (144000, 0.10, 2520),
+    (300000, 0.20, 16920),
+    (420000, 0.25, 31920),
+    (660000, 0.30, 52920),
+    (960000, 0.35, 85920),
+    (float("inf"), 0.45, 181920),
+]
+
+STANDARD_DEDUCTION = 60000
+
+
+@dataclass
+class TaxResult:
+    taxable_income: float
+    tax_rate: float
+    quick_deduction: float
+    tax_due: float
+    net_income: float
+
+
+def calculate_tax(annual_income: float, *, deductions: float = 0.0) -> TaxResult:
+    """Calculate annual tax for comprehensive income.
+
+    Args:
+        annual_income: Gross annual income before tax.
+        deductions: Additional deductible amount beyond the standard deduction.
+
+    Returns:
+        TaxResult summarizing the calculation.
+    """
+
+    if annual_income < 0:
+        raise ValueError("Annual income cannot be negative")
+    if deductions < 0:
+        raise ValueError("Deductions cannot be negative")
+
+    taxable_income = max(0.0, annual_income - STANDARD_DEDUCTION - deductions)
+
+    for upper, rate, quick in BRACKETS:
+        if taxable_income <= upper:
+            tax_due = max(taxable_income * rate - quick, 0.0)
+            net_income = annual_income - tax_due
+            return TaxResult(
+                taxable_income=taxable_income,
+                tax_rate=rate,
+                quick_deduction=quick,
+                tax_due=tax_due,
+                net_income=net_income,
+            )
+
+    # Should never reach here because the last bracket upper bound is infinity.
+    raise RuntimeError("Failed to find applicable tax bracket")
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="China personal income tax calculator")
+    parser.add_argument(
+        "--income",
+        type=float,
+        required=True,
+        help="Income amount. Interpret as monthly income when --monthly is used, otherwise annual income.",
+    )
+    parser.add_argument(
+        "--deductions",
+        type=float,
+        default=0.0,
+        help="Additional deductible amount besides social insurance and the standard deduction (annual).",
+    )
+    parser.add_argument(
+        "--social-insurance",
+        type=float,
+        default=0.0,
+        help="Total annual social insurance and housing fund contributions. If --monthly is provided, treat this as monthly and it will be annualized.",
+    )
+    parser.add_argument(
+        "--monthly",
+        action="store_true",
+        help="Interpret the provided income and social-insurance as monthly amounts.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_arguments()
+
+    multiplier = 12 if args.monthly else 1
+    annual_income = args.income * multiplier
+    annual_social = args.social_insurance * multiplier
+
+    result = calculate_tax(
+        annual_income,
+        deductions=args.deductions + annual_social,
+    )
+
+    if args.monthly:
+        print("Monthly mode (values shown in RMB):")
+        print(f"  Gross monthly income: {args.income:,.2f}")
+        print(f"  Monthly social insurance: {args.social_insurance:,.2f}")
+        print(f"  Monthly additional deductions: {args.deductions / 12:,.2f}")
+        print(f"  Monthly taxable income: {result.taxable_income / 12:,.2f}")
+        print(f"  Monthly tax due: {result.tax_due / 12:,.2f}")
+        print(f"  Monthly net income: {result.net_income / 12:,.2f}")
+    else:
+        print("Annual mode (values shown in RMB):")
+        print(f"  Gross annual income: {annual_income:,.2f}")
+        print(f"  Annual deductions (incl. social insurance): {args.deductions + annual_social:,.2f}")
+        print(f"  Taxable income: {result.taxable_income:,.2f}")
+        print(f"  Tax rate: {result.tax_rate * 100:.0f}%")
+        print(f"  Quick deduction: {result.quick_deduction:,.2f}")
+        print(f"  Tax due: {result.tax_due:,.2f}")
+        print(f"  Net income: {result.net_income:,.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tax_calculator.py
+++ b/tests/test_tax_calculator.py
@@ -1,0 +1,51 @@
+import unittest
+
+from tax_calculator import STANDARD_DEDUCTION, calculate_tax
+
+
+class TaxCalculatorTestCase(unittest.TestCase):
+    def test_zero_income(self):
+        result = calculate_tax(0)
+        self.assertEqual(result.taxable_income, 0)
+        self.assertEqual(result.tax_due, 0)
+        self.assertEqual(result.net_income, 0)
+
+    def test_typical_annual_income(self):
+        annual_income = 120_000
+        result = calculate_tax(annual_income)
+        self.assertAlmostEqual(result.taxable_income, annual_income - STANDARD_DEDUCTION)
+        self.assertAlmostEqual(result.tax_due, 3480.0)
+        self.assertAlmostEqual(result.net_income, annual_income - 3480.0)
+        self.assertAlmostEqual(result.tax_rate, 0.10)
+        self.assertAlmostEqual(result.quick_deduction, 2520.0)
+
+    def test_deductions_lower_taxable_income(self):
+        annual_income = 300_000
+        deductions = 50_000
+        result = calculate_tax(annual_income, deductions=deductions)
+        expected_taxable = max(0, annual_income - STANDARD_DEDUCTION - deductions)
+        self.assertAlmostEqual(result.taxable_income, expected_taxable)
+        self.assertAlmostEqual(result.tax_rate, 0.20)
+        self.assertAlmostEqual(result.quick_deduction, 16920.0)
+        self.assertAlmostEqual(result.tax_due, 21080.0)
+
+    def test_high_income_bracket(self):
+        annual_income = 1_200_000
+        result = calculate_tax(annual_income)
+        expected_taxable = annual_income - STANDARD_DEDUCTION
+        self.assertAlmostEqual(result.taxable_income, expected_taxable)
+        # For manual check: taxable income 1,140,000 -> highest bracket 45% quick deduction 181,920
+        expected_tax = expected_taxable * 0.45 - 181_920
+        self.assertAlmostEqual(result.tax_due, expected_tax)
+
+    def test_negative_income_raises(self):
+        with self.assertRaises(ValueError):
+            calculate_tax(-1)
+
+    def test_negative_deductions_raise(self):
+        with self.assertRaises(ValueError):
+            calculate_tax(100_000, deductions=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a unittest test suite covering typical, high, and edge-case tax calculations
- verify negative income and deductions raise validation errors

## Testing
- python -m unittest discover -s tests


------
https://chatgpt.com/codex/tasks/task_e_68e2469414d08320b81e626e0605730c